### PR TITLE
Flesh out core test suite and enforce tests-required convention

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Summary
+<!-- What does this PR change and why? Link the issue it closes, e.g. "Closes #8". -->
+
+## Checklist
+- [ ] New or changed functionality has accompanying tests under `tests/`.
+- [ ] `pytest --cov=src` passes locally, including the coverage gate (see `pyproject.toml`).
+- [ ] `pylint src/ --fail-under=8.0` passes.
+- [ ] Docs/README updated if behavior or setup changed.
+
+> Tests and the coverage gate run automatically on every PR via the **Test & Lint** workflow.
+> See [CONTRIBUTING.md](../CONTRIBUTING.md) for the project's testing convention.

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -19,7 +19,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
-      - name: Run tests
-        run: pytest --maxfail=1 --disable-warnings -q
+      - name: Run tests with coverage
+        run: pytest --cov=src --cov-report=term-missing --maxfail=1 --disable-warnings -q
       - name: Lint with pylint
         run: pylint src/ --fail-under=8.0

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ data/*.json
 __pycache__/
 *.pyc
 *_notes.txt
+.coverage
+htmlcov/
+.pytest_cache/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing
+
+Thanks for contributing to the Strong Data Project. This document covers the
+project's testing convention and how the CI gate works.
+
+## Testing convention
+
+**New or changed functionality must ship with tests.** This is not just a
+guideline — it is enforced mechanically:
+
+- Tests live in `tests/`, one file per source module (`test_<module>.py`).
+- Core logic — parsing (`parsers.py`, `utils/parse_utils.py`), data models
+  (`models.py`), GUI helpers (`utils/gui_utils.py`), and the mapping CLI
+  (`scripts/parse_raw_data.py`) — is covered by unit tests.
+- A coverage gate (`fail_under` in `pyproject.toml`) runs on every PR. Adding
+  untested logic lowers coverage and **fails CI**, so the convention is upheld
+  even when a reviewer forgets to check.
+
+Pure Streamlit page modules (`home.py`, `graphs.py`, `edit.py`, `upload.py`,
+`scripts/gui.py`) are render glue and are excluded from coverage measurement via
+the `omit` list in `pyproject.toml`. Put testable logic in the helper/parser
+modules so it can be covered.
+
+## Running tests locally
+
+Install dev dependencies, then run the suite with coverage:
+
+```bash
+pip3 install -r requirements-dev.txt
+
+pytest --cov=src --cov-report=term-missing
+
+pylint src/ --fail-under=8.0
+```
+
+`pytest` is configured via `pyproject.toml` (`pythonpath = ["src"]`), so imports
+like `from models import Workout` work without any manual path setup.
+
+## CI gate
+
+The **Test & Lint** workflow (`.github/workflows/test-lint.yml`) runs `pytest`
+with coverage and `pylint` on every pull request and on pushes to `main`. A PR
+must pass this workflow to be merge-ready.
+
+> **Maintainer note:** to make the workflow a *required* status check (blocking
+> merge), enable branch protection on `main` in the GitHub repository settings
+> (Settings → Branches → Add rule → require status checks → "test-lint"). This is
+> a one-time GitHub setting and cannot be configured from version-controlled
+> files.

--- a/README.md
+++ b/README.md
@@ -75,10 +75,13 @@ To test & lint functionality perform the following steps:
     ```
 2. Run the tests & linting with the following commands - note these will be done on PR as well, but linting only requires a score of 8.0 to pass.
     ```bash
-    pytest
-    
+    pytest --cov=src --cov-report=term-missing
+
     pylint src
     ```
+   Tests run with a coverage gate (configured in `pyproject.toml`), so PRs that add untested core logic will fail CI.
+
+New and changed functionality must come with tests. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the testing convention and details on the CI gate.
 
 ## Further Help
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]
+
+[tool.coverage.run]
+source = ["src"]
+omit = [
+    "*/home.py",
+    "*/graphs.py",
+    "*/edit.py",
+    "*/upload.py",
+    "*/scripts/gui.py",
+]
+
+[tool.coverage.report]
+show_missing = true
+fail_under = 95

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 # Add test dependencies
 pytest
+pytest-cov
 pylint

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,54 @@
+"""Shared pytest fixtures for the test suite.
+
+Test imports such as ``from models import Workout`` resolve because
+``pythonpath = ["src"]`` is configured in pyproject.toml, so no manual
+``sys.path`` manipulation is needed here.
+"""
+from datetime import datetime
+
+import pytest
+
+from models import Workout, Exercise, ExerciseSet, BodyPart
+
+
+@pytest.fixture
+def sample_workouts() -> list[Workout]:
+    """Two in-memory workouts with exercises and sets for model/filter tests."""
+    bench = Exercise("Bench Press", body_part=BodyPart.PECS)
+    squat = Exercise("Squat", body_part=BodyPart.QUADS)
+    curl = Exercise("Bicep Curl", body_part=BodyPart.BICEPS)
+
+    push_day = Workout("Push", datetime(2026, 1, 1, 9, 0, 0), duration=60)
+    leg_day = Workout("Legs", datetime(2026, 2, 1, 9, 0, 0), duration=45)
+
+    bench.exercise_sets.append(
+        ExerciseSet(push_day.name, push_day.date, set_number=1, weight=100, reps=10)
+    )
+    bench.exercise_sets.append(
+        ExerciseSet(push_day.name, push_day.date, set_number=2, weight=110, reps=8)
+    )
+    curl.exercise_sets.append(
+        ExerciseSet(push_day.name, push_day.date, set_number=1, weight=30, reps=12)
+    )
+    squat.exercise_sets.append(
+        ExerciseSet(leg_day.name, leg_day.date, set_number=1, weight=200, reps=5)
+    )
+
+    push_day.exercises.extend([bench, curl])
+    leg_day.exercises.append(squat)
+    return [push_day, leg_day]
+
+
+@pytest.fixture
+def sample_csv(tmp_path) -> str:
+    """Write a Strong-format CSV (incl. a warmup set and two workouts) and return its path."""
+    rows = [
+        "Date,Workout Name,Duration,Exercise Name,Set Order,Weight,Reps,Notes,Workout Notes",
+        '2026-01-01 09:00:00,Push,1h 0m,Bench Press,W,45,10,,Felt good',
+        '2026-01-01 09:00:00,Push,1h 0m,Bench Press,1,100,8,,Felt good',
+        '2026-01-01 09:00:00,Push,1h 0m,Bicep Curl,1,30,12,light,Felt good',
+        '2026-02-01 09:00:00,Legs,45m,Squat,1,200,5,,',
+    ]
+    csv_path = tmp_path / "strong.csv"
+    csv_path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+    return str(csv_path)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,9 +1,6 @@
-import sys
-import os
 import types
 from unittest.mock import MagicMock
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
-sys.path.insert(0, '/Users/parkerlacy/coding/strong-data/src')
+
 import scripts.gui as gui
 
 def test_main_calls_navigation(monkeypatch):

--- a/tests/test_gui_utils.py
+++ b/tests/test_gui_utils.py
@@ -1,0 +1,61 @@
+"""Tests for the pure GUI helper functions."""
+import types
+from datetime import date
+
+from utils import gui_utils
+from utils.gui_utils import filter_workouts
+
+
+def test_filter_workouts_keeps_in_range(sample_workouts):
+    # sample_workouts span 2026-01-01 (Push) and 2026-02-01 (Legs).
+    result = filter_workouts(sample_workouts, [date(2026, 1, 1), date(2026, 1, 31)])
+    assert [w.name for w in result] == ["Push"]
+
+
+def test_filter_workouts_inclusive_bounds(sample_workouts):
+    result = filter_workouts(sample_workouts, [date(2026, 1, 1), date(2026, 2, 1)])
+    assert len(result) == 2
+
+
+def test_filter_workouts_non_pair_range_returns_all(sample_workouts):
+    # A single-element range (mid-selection in the UI) should not filter anything out.
+    result = filter_workouts(sample_workouts, [date(2026, 1, 1)])
+    assert result == sample_workouts
+
+
+def test_initialize_page_seeds_workouts_once(monkeypatch, sample_workouts):
+    fake_state = {}
+    monkeypatch.setattr(gui_utils, "st", types.SimpleNamespace(session_state=fake_state))
+    monkeypatch.setattr(gui_utils, "load_workouts", lambda: sample_workouts)
+
+    gui_utils.initialize_page()
+    assert fake_state["workouts"] == sample_workouts
+
+    # A second call must not reload over an existing value.
+    monkeypatch.setattr(gui_utils, "load_workouts", lambda: [])
+    gui_utils.initialize_page()
+    assert fake_state["workouts"] == sample_workouts
+
+
+def test_render_page_with_workouts_passes_date_bounds(monkeypatch, sample_workouts):
+    fake_state = {"workouts": sample_workouts}
+    monkeypatch.setattr(gui_utils, "st", types.SimpleNamespace(session_state=fake_state))
+
+    captured = {}
+
+    def render(workouts, min_date, max_date):
+        captured["args"] = (workouts, min_date, max_date)
+
+    gui_utils.render_page_with_workouts(render)
+    assert captured["args"] == (sample_workouts, date(2026, 1, 1), date(2026, 2, 1))
+
+
+def test_render_page_with_workouts_empty_writes_message(monkeypatch):
+    messages = []
+    fake_st = types.SimpleNamespace(
+        session_state={"workouts": []}, write=messages.append
+    )
+    monkeypatch.setattr(gui_utils, "st", fake_st)
+
+    gui_utils.render_page_with_workouts(lambda *a: None)
+    assert messages and "No data available" in messages[0]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,51 @@
+"""Tests for the aggregation properties on the core data models."""
+from datetime import datetime
+
+from models import Workout, Exercise, ExerciseSet, BodyPart
+
+
+def _set(weight: float, reps: int) -> ExerciseSet:
+    return ExerciseSet("W", datetime(2026, 1, 1), set_number=1, weight=weight, reps=reps)
+
+
+def test_exercise_number_of_times_performed():
+    exercise = Exercise("Bench Press", body_part=BodyPart.PECS)
+    exercise.exercise_sets.extend([_set(100, 10), _set(110, 8)])
+    assert exercise.number_of_times_performed == 2
+
+
+def test_exercise_last_performed_returns_latest_date():
+    exercise = Exercise("Bench Press")
+    exercise.exercise_sets.append(
+        ExerciseSet("W", "2026-01-01", set_number=1, weight=100, reps=10)
+    )
+    exercise.exercise_sets.append(
+        ExerciseSet("W", "2026-03-15", set_number=1, weight=120, reps=6)
+    )
+    assert exercise.last_performed == "2026-03-15"
+
+
+def test_exercise_last_performed_empty_is_none():
+    assert Exercise("Bench Press").last_performed is None
+
+
+def test_workout_aggregate_properties():
+    workout = Workout("Push", datetime(2026, 1, 1), duration=60)
+    bench = Exercise("Bench Press", body_part=BodyPart.PECS)
+    curl = Exercise("Bicep Curl", body_part=BodyPart.BICEPS)
+    bench.exercise_sets.extend([_set(100, 10), _set(110, 8)])
+    curl.exercise_sets.append(_set(30, 12))
+    workout.exercises.extend([bench, curl])
+
+    assert workout.number_of_exercises == 2
+    assert workout.number_of_exercise_sets == 3
+    assert workout.total_weight_lifted == 240
+    assert workout.total_reps_performed == 30
+
+
+def test_empty_workout_aggregates_are_zero():
+    workout = Workout("Rest", datetime(2026, 1, 1), duration=0)
+    assert workout.number_of_exercises == 0
+    assert workout.number_of_exercise_sets == 0
+    assert workout.total_weight_lifted == 0
+    assert workout.total_reps_performed == 0

--- a/tests/test_parse_raw_data.py
+++ b/tests/test_parse_raw_data.py
@@ -1,0 +1,66 @@
+"""Tests for the command-line mapping helpers in scripts.parse_raw_data."""
+import json
+
+from models import BodyPart
+from scripts import parse_raw_data
+from scripts.parse_raw_data import (
+    EXIT_FLAG,
+    main_flow,
+    prompt_for_body_part,
+    save_mappings,
+)
+from utils.parse_utils import load_mappings
+
+
+def test_save_mappings_round_trips(tmp_path):
+    mapping_file = tmp_path / "mappings.json"
+    data = {"Bench Press": "Pecs", "Squat": "Quads"}
+    save_mappings(data, str(mapping_file))
+
+    assert json.loads(mapping_file.read_text(encoding="utf-8")) == data
+    assert load_mappings(str(mapping_file)) == data
+
+
+def test_prompt_for_body_part_valid_choice(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _="": "1")
+    first_body_part = list(BodyPart)[0].value
+    assert prompt_for_body_part("Shrug") == first_body_part
+
+
+def test_prompt_for_body_part_quit_returns_exit_flag(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _="": "q")
+    assert prompt_for_body_part("Shrug") == EXIT_FLAG
+
+
+def test_prompt_for_body_part_non_digit_returns_none(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _="": "abc")
+    assert prompt_for_body_part("Shrug") is None
+
+
+def test_prompt_for_body_part_out_of_range_returns_none(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _="": "9999")
+    assert prompt_for_body_part("Shrug") is None
+
+
+def test_main_flow_quit_saves_no_mappings(monkeypatch, tmp_path, sample_csv):
+    # No pre-existing mapping file, so every parsed exercise is prompted for.
+    monkeypatch.setattr(parse_raw_data, "MAPPING_FILE", str(tmp_path / "missing.json"))
+    monkeypatch.setattr("builtins.input", lambda _="": "q")
+    out_file = tmp_path / "out.json"
+
+    main_flow(file_path=sample_csv, mapping_file=str(out_file))
+
+    assert json.loads(out_file.read_text(encoding="utf-8")) == {}
+
+
+def test_main_flow_maps_every_exercise(monkeypatch, tmp_path, sample_csv):
+    monkeypatch.setattr(parse_raw_data, "MAPPING_FILE", str(tmp_path / "missing.json"))
+    monkeypatch.setattr("builtins.input", lambda _="": "1")
+    out_file = tmp_path / "out.json"
+
+    main_flow(file_path=sample_csv, mapping_file=str(out_file))
+
+    saved = json.loads(out_file.read_text(encoding="utf-8"))
+    first_body_part = list(BodyPart)[0].value
+    assert set(saved) == {"Bench Press", "Bicep Curl", "Squat"}
+    assert all(value == first_body_part for value in saved.values())

--- a/tests/test_parse_utils.py
+++ b/tests/test_parse_utils.py
@@ -1,0 +1,55 @@
+"""Tests for the pure parsing helpers in utils.parse_utils."""
+import pytest
+
+from utils.parse_utils import (
+    load_mappings,
+    parse_duration,
+    parse_set_order,
+    parse_to_int,
+)
+
+
+@pytest.mark.parametrize(
+    "duration_str, expected",
+    [
+        ("53m", 53),
+        ("1h 31m", 91),
+        ("32h 5m", 1925),
+        ("2h", 120),
+    ],
+)
+def test_parse_duration(duration_str, expected):
+    assert parse_duration(duration_str) == expected
+
+
+@pytest.mark.parametrize("set_order, expected", [("1", 1), ("12", 12), ("0", 0)])
+def test_parse_set_order_numeric(set_order, expected):
+    assert parse_set_order(set_order) == expected
+
+
+@pytest.mark.parametrize("special", ["W", "F", "D"])
+def test_parse_set_order_special_cases_are_zero(special):
+    assert parse_set_order(special) == 0
+
+
+def test_parse_set_order_invalid_raises():
+    with pytest.raises(ValueError):
+        parse_set_order("X")
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [("0", 0), ("0.0", 0), ("42", 42), ("12.9", 12), ("junk", 0), ("", 0)],
+)
+def test_parse_to_int(value, expected):
+    assert parse_to_int(value) == expected
+
+
+def test_load_mappings_reads_existing_file(tmp_path):
+    mapping_file = tmp_path / "mappings.json"
+    mapping_file.write_text('{"Bench Press": "Pecs"}', encoding="utf-8")
+    assert load_mappings(str(mapping_file)) == {"Bench Press": "Pecs"}
+
+
+def test_load_mappings_missing_file_returns_empty(tmp_path):
+    assert load_mappings(str(tmp_path / "does_not_exist.json")) == {}

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,102 @@
+"""Tests for CSV parsing and the workout/exercise builder helpers."""
+from datetime import datetime
+
+from models import Workout, BodyPart
+from parsers import (
+    get_or_create_workout,
+    get_or_create_exercise,
+    load_workouts,
+    parse_body_part,
+    parse_csv,
+)
+
+
+def test_get_or_create_workout_creates_then_reuses():
+    workouts = {}
+    key = ("2026-01-01 09:00:00", "Push")
+    first = get_or_create_workout(
+        workouts, key, "Push", datetime(2026, 1, 1), 60, ""
+    )
+    second = get_or_create_workout(
+        workouts, key, "Push", datetime(2026, 1, 1), 60, ""
+    )
+    assert first is second
+    assert len(workouts) == 1
+
+
+def test_get_or_create_exercise_creates_then_reuses():
+    workout = Workout("Push", datetime(2026, 1, 1), duration=60)
+    first = get_or_create_exercise(workout, "Bench Press", BodyPart.PECS)
+    second = get_or_create_exercise(workout, "Bench Press", BodyPart.PECS)
+    assert first is second
+    assert workout.number_of_exercises == 1
+
+
+def test_parse_body_part_known_mapping_returns_enum():
+    mappings = {"Bench Press": "Pecs"}
+    assert parse_body_part("Bench Press", mappings) is BodyPart.PECS
+
+
+def test_parse_body_part_unknown_returns_none():
+    assert parse_body_part("Unknown Lift", {}) is None
+
+
+def test_parse_body_part_invalid_value_falls_back_to_a_body_part():
+    # A mapping pointing at a string with no matching enum member falls back to a random part.
+    result = parse_body_part("Bench Press", {"Bench Press": "NotARealPart"})
+    assert result in list(BodyPart)
+
+
+def test_parse_csv_builds_object_graph(sample_csv, tmp_path):
+    mapping_file = tmp_path / "mappings.json"
+    mapping_file.write_text(
+        '{"Bench Press": "Pecs", "Bicep Curl": "Biceps", "Squat": "Quads"}',
+        encoding="utf-8",
+    )
+
+    workouts = parse_csv(sample_csv, mappings_path=str(mapping_file))
+
+    # Two distinct (date, name) keys -> two workouts.
+    assert len(workouts) == 2
+    by_name = {w.name: w for w in workouts}
+
+    push = by_name["Push"]
+    assert push.duration == 60
+    assert push.number_of_exercises == 2
+    # Warmup ("W") + regular set on bench, plus one curl set.
+    assert push.number_of_exercise_sets == 3
+
+    bench = next(e for e in push.exercises if e.name == "Bench Press")
+    assert bench.body_part is BodyPart.PECS
+    # Warmup row parses to set_number 0, regular row to 1.
+    assert sorted(s.set_number for s in bench.exercise_sets) == [0, 1]
+
+    legs = by_name["Legs"]
+    assert legs.duration == 45
+    assert legs.number_of_exercise_sets == 1
+
+
+def test_load_workouts_missing_file_returns_empty(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["prog", "/no/such/file.csv"])
+    assert load_workouts() == []
+
+
+def test_load_workouts_no_argument_returns_empty(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["prog"])
+    assert load_workouts() == []
+
+
+def test_load_workouts_parse_error_returns_empty(monkeypatch, sample_csv):
+    monkeypatch.setattr("sys.argv", ["prog", sample_csv])
+
+    def boom(_path):
+        raise ValueError("bad data")
+
+    monkeypatch.setattr("parsers.parse_csv", boom)
+    assert load_workouts() == []
+
+
+def test_load_workouts_parses_valid_file(monkeypatch, sample_csv):
+    monkeypatch.setattr("sys.argv", ["prog", sample_csv])
+    workouts = load_workouts()
+    assert len(workouts) == 2


### PR DESCRIPTION
Closes #8

## Summary
Builds out a real unit test suite for the core logic and bakes in a mechanically-enforced convention that new functionality must ship with tests.

- **Coverage**: 1 smoke test → **48 tests**, core coverage ~0% → **97.49%**.
- **Enforced convention**: a coverage gate (`fail_under=95` in `pyproject.toml`) now runs in CI, so a PR that adds untested core logic fails the build — not just a documented guideline.

## Changes
- **Tests** (`tests/`): new `test_models.py`, `test_parse_utils.py`, `test_parsers.py`, `test_gui_utils.py`, `test_parse_raw_data.py`, plus `conftest.py` with shared `sample_workouts` / `sample_csv` fixtures. Covers model aggregation properties, duration/set-order/int parsing, `parse_csv` object-graph building (incl. warmup set + `(date, name)` grouping edge cases), date filtering, and the mapping CLI.
- **Config** (`pyproject.toml`): pytest `pythonpath=["src"]` (no more `sys.path` hacks) and coverage config (`fail_under=95`, omits pure-Streamlit page modules).
- **CI** (`.github/workflows/test-lint.yml`): runs `pytest --cov=src`; `requirements-dev.txt` adds `pytest-cov`.
- **Docs**: new `.github/pull_request_template.md` and `CONTRIBUTING.md` documenting the testing convention; README points to it.
- **Cleanups**: dropped the hardcoded `/Users/parkerlacy/...` path from `test_gui.py`; fixed a missing-newline bug in `.gitignore`.

## Test plan
- [x] `pytest --cov=src` → 48 passed, gate satisfied (97.49% ≥ 95%)
- [x] `pylint src/ --fail-under=8.0` → 9.72/10

## Maintainer note
To make this a *required* merge gate, enable branch protection on `main` (Settings → Branches → require the `test-lint` status check). This is a one-time GitHub setting and can't live in version-controlled files; details are in `CONTRIBUTING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)